### PR TITLE
Update repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Clone the repo to your home folder. It may be a good idea to fork the repository
 and then clone it from your fork.
 
     $ cd ~
-    $ git clone git@bitbucket.org:instilled/.zsh.git
+    $ git clone git@github.com:nicolascepeda/.zsh.git
 
 Now symlink `.zsh/zshrc` and `.zsh/zshenv` to `~`:
 


### PR DESCRIPTION
Using bitbucket repo URL i got the following warning:
```
Cloning into '.zsh'...
Warning: Permanently added the RSA host key for IP address '104.192.143.1' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
Using git repo URL worked for me.

Thanks for proving this zsh setup! It's my favourite one :)